### PR TITLE
Fix overflow on members page for firefox

### DIFF
--- a/members.css
+++ b/members.css
@@ -1,6 +1,6 @@
 body {
     font-family: exo;
-    overflow: overlay;
+    overflow: auto;
 }
 
 #main {


### PR DESCRIPTION
Changed overflow to auto, which behaves similarly but has better support.